### PR TITLE
Resolve array indexing issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 .DS_Store
 boot.dol
 boot.elf

--- a/source/main.c
+++ b/source/main.c
@@ -141,10 +141,10 @@ int main(int argc, char *argv[])
 			printf("Press the B Button to confirm.\n");
 			printf("Press HOME or Start to exit.");
 
-			filenames[1] = "/shared2/wc24/mbox/wc24recv.ctl";
-			filenames[2] = "/shared2/wc24/mbox/wc24recv.mbx";
-			filenames[3] = "/shared2/wc24/mbox/wc24send.ctl";
-			filenames[4] = "/shared2/wc24/mbox/wc24send.mbx";
+			filenames[0] = "/shared2/wc24/mbox/wc24recv.ctl";
+			filenames[1] = "/shared2/wc24/mbox/wc24recv.mbx";
+			filenames[2] = "/shared2/wc24/mbox/wc24send.ctl";
+			filenames[3] = "/shared2/wc24/mbox/wc24send.mbx";
 
 			size = 4;
 


### PR DESCRIPTION
Somebody brought #1 to my attention - the function at 0x80036658 is `strlen`. 0x80038c20 is `snprintf`, and called as follows:
https://github.com/RiiConnect24/RC24-Clear-Tool/blob/338eaa4e277c39ced6094b198b72f8cea0ccfa5f/source/main.c#L220

For mailboxes specifically, it seems the array was erroneously one indexed:
https://github.com/RiiConnect24/RC24-Clear-Tool/blob/338eaa4e277c39ced6094b198b72f8cea0ccfa5f/source/main.c#L144-L147
 `snprintf` would then proceed to access filenames[0] (which is null) and crash.

Thankfully nothing too insane. :)
Closes #1.